### PR TITLE
Suggested changes for API for task 3

### DIFF
--- a/src/joint_embedding/README.md
+++ b/src/joint_embedding/README.md
@@ -18,7 +18,7 @@ This component expects two h5ad files, `--input_mod1` and `--input_mod2`. They b
 
   * `.X`: Sparse profile matrix.
   * `.uns['dataset_id']`: The name of the dataset.
-  * `.obs['batch']`: Batch id (optional).
+  * `.obs['batch']`: Batch id.
   * `.var['gene_ids']`: Additional gene Ids (optional).
   * `.var['feature_types']`: The modality of this file, should be equal to `"GEX"`, `"ATAC"` or `"ADT"`.
   * `.obs_names`: Ids for the cells.
@@ -32,7 +32,7 @@ The `output_mod1` and `output_mod2` files contain the full profile matrices wher
 
   * `.X`: Sparse profile matrix.
   * `.uns['dataset_id']`: The name of the dataset.
-  * `.obs['batch']`: Batch id (optional).
+  * `.obs['batch']`: Batch id.
   * `.var['gene_ids']`: Additional gene Ids (optional).
   * `.var['feature_types']`: The modality of this file, should be equal to `"GEX"`, `"ATAC"` or `"ADT"`.
   * `.obs_names`: Ids for the cells.
@@ -41,6 +41,7 @@ The `output_mod1` and `output_mod2` files contain the full profile matrices wher
 The `output_solution` file contains metadata on the cell profiles, which will be used to evaluate whether similar cells have been positioned closely to one another in the embedding.
 
   * `.obs["cell_type"]`: The cell type each cell belongs to.
+  * `.obs['batch']`: Batch id.  
   * `.uns['dataset_id']`: The name of the dataset.
   * `.obs_names`: Ids for the cells.
 
@@ -55,6 +56,7 @@ This component expects two h5ad files, `--input_mod1` and `--input_mod2`, contai
   * `.X`: Sparse profile matrix.
   * `.uns['dataset_id']`: The name of the dataset.
   * `.var['feature_types']`: The modality of this file, should be equal to `"GEX"`, `"ATAC"` or `"ADT"`.
+  * `.obs['batch']`: Batch ids for all concatenated dataset batches.
   * `.obs_names`: Ids for the cells.
   * `.var_names`: Ids for the features.
 
@@ -65,6 +67,7 @@ This component should output *one* h5ad file, `--output_prediction`, containing 
   * `.X`: The embedding matrix of the cells.
   * `.uns['dataset_id']`: The name of the dataset.
   * `.uns['method_id']`: The name of the prediction method.
+  * `.obs['batch']`: Batch id.
   * `.obs_names`: Ids for the cells.
 
 The embedding should have **at most 100 columns**.
@@ -82,11 +85,13 @@ The `input_prediction` file has the following attributes:
   * `.X`: The embedding matrix of the cells (at most 100 columns).
   * `.uns['dataset_id']`: The name of the dataset.
   * `.uns['method_id']`: The name of the prediction method.
+  * `.obs['batch']`: Batch id.
   * `.obs_names`: Ids for the cells.
 
 The `input_solution` file has the following attributes.
 
   * `.obs["cell_type"]`: The cell type each cell belongs to.
+  * `.obs['batch']`: Batch id.
   * `.uns['dataset_id']`: The name of the dataset.
   * `.obs_names`: Ids for the cells.
 


### PR DESCRIPTION
Hey!

I finally got around to looking at the API for task 3 and made some suggested changes. The main aspect I think is that `adata.obs['batch']` should be required for the metrics to work nicely. In the end we are evaluating also how well the embedding integrated across batches.

Another aspect, I haven't touched yet is whether we can have the metrics output a tsv file instead of an `AnnData` object? We could then concatenate all individual metric tsv results at the end to generate one output file? This would make it easier to have the modular metric addition that we now have. What do you think @rcannood ?