### PR TITLE
Add Joint embedding dummy methods

### DIFF
--- a/src/joint_embedding/README.md
+++ b/src/joint_embedding/README.md
@@ -78,7 +78,7 @@ A component which compares the predicted embedding against the ground-truth cell
 
 #### Input data formats
 
-This component should output two h5ad files, `--input_prediction` and `--input_solution`.
+This component expects two h5ad files, `--input_prediction` and `--input_solution`.
 
 The `input_prediction` file has the following attributes:
 

--- a/src/joint_embedding/methods/dummy_random/config.vsh.yaml
+++ b/src/joint_embedding/methods/dummy_random/config.vsh.yaml
@@ -1,0 +1,43 @@
+functionality:
+  name: dummy_random
+  namespace: joint_embedding_methods
+  version: dev
+  description: A dummy method for comparing joint embedding methods against. Embeds with gaussian distributued values.
+  authors:
+    - name: Alex Tong
+      email: alexandertongdev@gmail.com
+      roles: [ author, maintainer ]
+      props: { github: atong01 }
+  arguments:
+    - name: "--input_mod1"
+      type: "file"
+      example: "dataset_mod1.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--input_mod2"
+      type: "file"
+      example: "dataset_mod2.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--output"
+      type: "file"
+      direction: "output"
+      example: "output.h5ad"
+      description: Dataset with predicted values for modality2.
+      required: true
+    - name: "--n_dims"
+      type: "integer"
+      default: 100
+      description: Number of dimensions to output.
+  resources:
+    - type: python_script
+      path: script.py
+platforms:
+  - type: docker
+    image: "python:3.8"
+    setup:
+      - type: python
+        pip: [ anndata, numpy ]
+  - type: nextflow
+    directive_time: 10m
+    directive_memory: "20 GB"

--- a/src/joint_embedding/methods/dummy_random/script.py
+++ b/src/joint_embedding/methods/dummy_random/script.py
@@ -1,0 +1,23 @@
+import anndata
+import numpy as np
+
+## VIASH START
+par = {
+    "input_mod1": "resources_test/joint_embedding/test_resource.mod1.h5ad",
+    "input_mod2": "resources_test/joint_embedding/test_resource.mod2.h5ad",
+    "output": "tmp/output_prediction.h5ad",
+    "n_dims": 100,
+}
+## VIASH END
+
+print("Load and prepare data")
+adata_mod1 = anndata.read_h5ad(par["input_mod1"])
+
+X = np.random.randn(adata_mod1.shape[0], par["n_dims"])
+print("Saving output")
+adata_out = anndata.AnnData(
+    X=X,
+    obs=adata_mod1.obs[["batch"]],
+    uns={"dataset_id": adata_mod1.uns["dataset_id"], "method_id": "dummy_random"},
+)
+adata_out.write_h5ad(par["output"], compression="gzip")

--- a/src/joint_embedding/methods/dummy_single_mod/config.vsh.yaml
+++ b/src/joint_embedding/methods/dummy_single_mod/config.vsh.yaml
@@ -1,0 +1,49 @@
+functionality:
+  name: dummy_single_mod
+  namespace: joint_embedding_methods
+  version: dev
+  description: A dummy method for comparing joint embedding methods against.
+    Only uses the PCA embedding of a specified modality. Its possible that for
+    some data using only one modality will work better than using both.
+  authors:
+    - name: Alex Tong
+      email: alexandertongdev@gmail.com
+      roles: [ author, maintainer ]
+      props: { github: atong01 }
+  arguments:
+    - name: "--input_mod1"
+      type: "file"
+      example: "dataset_mod1.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--input_mod2"
+      type: "file"
+      example: "dataset_mod2.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--output"
+      type: "file"
+      direction: "output"
+      example: "output.h5ad"
+      description: Dataset with predicted values for modality2.
+      required: true
+    - name: "--n_dims"
+      type: "integer"
+      default: 1
+      description: Number of dimensions to output.
+    - name: "--modality"
+      type: "integer"
+      default: 1
+      description: Modality to embed with PCA.
+  resources:
+    - type: python_script
+      path: script.py
+platforms:
+  - type: docker
+    image: "python:3.8"
+    setup:
+      - type: python
+        pip: [ anndata, numpy, scanpy ]
+  - type: nextflow
+    directive_time: 10m
+    directive_memory: "20 GB"

--- a/src/joint_embedding/methods/dummy_single_mod/script.py
+++ b/src/joint_embedding/methods/dummy_single_mod/script.py
@@ -1,0 +1,28 @@
+import anndata
+import numpy as np
+import scanpy as sc
+
+## VIASH START
+par = {
+    "input_mod1": "resources_test/joint_embedding/test_resource.mod1.h5ad",
+    "input_mod2": "resources_test/joint_embedding/test_resource.mod2.h5ad",
+    "output": "tmp/output_prediction.h5ad",
+    "n_dims": 1,
+    "modality": 1,
+}
+## VIASH END
+
+assert 1 <= par["modality"] <= 2
+print("Load and prepare data")
+
+adata = anndata.read_h5ad(par["input_mod1" if par["modality"] == 1 else "input_mod2"])
+
+sc.tl.pca(adata, n_comps=100)
+
+print("Saving output")
+adata_out = anndata.AnnData(
+    X=adata.obsm["X_pca"],
+    obs=adata.obs[["batch"]],
+    uns={"dataset_id": adata.uns["dataset_id"], "method_id": "dummy_single_mod"},
+)
+adata_out.write_h5ad(par["output"], compression="gzip")

--- a/src/joint_embedding/methods/dummy_zeros/config.vsh.yaml
+++ b/src/joint_embedding/methods/dummy_zeros/config.vsh.yaml
@@ -1,0 +1,43 @@
+functionality:
+  name: dummy_zeros
+  namespace: joint_embedding_methods
+  version: dev
+  description: A baseline method for comparing joint embedding methods against.
+  authors:
+    - name: Alex Tong
+      email: alexandertongdev@gmail.com
+      roles: [ author, maintainer ]
+      props: { github: atong01 }
+  arguments:
+    - name: "--input_mod1"
+      type: "file"
+      example: "dataset_mod1.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--input_mod2"
+      type: "file"
+      example: "dataset_mod2.h5ad"
+      description: Censored dataset.
+      required: true
+    - name: "--output"
+      type: "file"
+      direction: "output"
+      example: "output.h5ad"
+      description: Dataset with predicted values for modality2.
+      required: true
+    - name: "--n_dims"
+      type: "integer"
+      default: 1
+      description: Number of dimensions to output.
+  resources:
+    - type: python_script
+      path: script.py
+platforms:
+  - type: docker
+    image: "python:3.8"
+    setup:
+      - type: python
+        pip: [ anndata, numpy ]
+  - type: nextflow
+    directive_time: 10m
+    directive_memory: "20 GB"

--- a/src/joint_embedding/methods/dummy_zeros/script.py
+++ b/src/joint_embedding/methods/dummy_zeros/script.py
@@ -1,0 +1,23 @@
+import anndata
+import numpy as np
+
+## VIASH START
+par = {
+    "input_mod1": "resources_test/joint_embedding/test_resource.mod1.h5ad",
+    "input_mod2": "resources_test/joint_embedding/test_resource.mod2.h5ad",
+    "output": "tmp/output_prediction.h5ad",
+    "n_dims": 1,
+}
+## VIASH END
+
+print("Load and prepare data")
+adata_mod1 = anndata.read_h5ad(par["input_mod1"])
+
+X = np.zeros((adata_mod1.shape[0], par["n_dims"]))
+print("Saving output")
+adata_out = anndata.AnnData(
+    X=X,
+    obs=adata_mod1.obs[["batch"]],
+    uns={"dataset_id": adata_mod1.uns["dataset_id"], "method_id": "dummy_zeros"},
+)
+adata_out.write_h5ad(par["output"], compression="gzip")


### PR DESCRIPTION
We add three dummy methods for the joint embedding task
* `dummy_zeros` -- embedding each cell to the all zeros vector
* `dummy_random` -- embedding each cell to a normally distributed vector
* `dummy_single_mod` -- embedding based on PCA of a single modality (Can specify modality).

These were the ones I could think of that make sense. Let me know if there are others.